### PR TITLE
extremely minor

### DIFF
--- a/optparse.php
+++ b/optparse.php
@@ -1723,4 +1723,3 @@ class OptionError extends Exception {
 class OptionValueError extends Exception { }
 
 } // __OPTPARSE_PHP
-?>


### PR DESCRIPTION
removing closing php bracket to avoid extra bad whitespace afterwards (can be a problem if including this file before headers are sent)
